### PR TITLE
Allow installing with Ruby 3

### DIFF
--- a/xcpretty-travis-formatter.gemspec
+++ b/xcpretty-travis-formatter.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{xcpretty custom formatter for TravisCI}
   spec.homepage      = "https://github.com/kattrali/xcpretty-travis-formatter"
   spec.license       = "MIT"
-  spec.required_ruby_version = "~> 2.0"
+  spec.required_ruby_version = ">= 2.0"
   spec.files         = [
   	"README.md",
   	"LICENSE",


### PR DESCRIPTION
This PR loosens the required Ruby version from `~> 2.0` to `>= 2.0`, allowing `xcpretty-travis-formatter` to be installed with Ruby 3