### PR TITLE
Call uniq before printing errors and warnings

### DIFF
--- a/lib/travis_formatter.rb
+++ b/lib/travis_formatter.rb
@@ -15,14 +15,14 @@ class TravisFormatter < XCPretty::Simple
       # Print out any warnings.
       if !@warnings.compact.empty?
         open_fold("Warnings")
-        STDOUT.puts @warnings.compact.join("\n")
+        STDOUT.puts @warnings.compact.uniq.join("\n")
         close_fold()
       end
 
       # Print out any errors.
       if !@errors.compact.empty?
         open_fold("Errors")
-        STDOUT.puts @errors.compact.join("\n")
+        STDOUT.puts @errors.compact.uniq.join("\n")
         exit(1)
       end
     end


### PR DESCRIPTION
I was getting a lot of duplicate warning output from cocoapod dependencies, seems like the warning got added again every time the file was imported or something. Using uniq seems to cut this down efficiently, actually improving performance. Unfortunately my builds are private so I can't link to them.

Old 
14170-10398 = 3772 lines
2:31:58-2:31:44 = 14 seconds

New
10684-10408 = 276 lines
14:40:18-14:40:17 = 1 second

93% shorter and 93% faster